### PR TITLE
Humidity packet

### DIFF
--- a/radio-packet-format/radio_packet_format.tex
+++ b/radio-packet-format/radio_packet_format.tex
@@ -1,6 +1,5 @@
 \documentclass[11pt,letterpaper]{article}
 
-% PACKAGES
 \usepackage[utf8]{inputenc}
 \usepackage[top=2.54cm,bottom=2.54cm,left=4cm,right=2.5cm,headheight=14pt]{geometry}
 \usepackage{graphicx} % Include images

--- a/radio-packet-format/sections/packets/blocks/data/data.tex
+++ b/radio-packet-format/sections/packets/blocks/data/data.tex
@@ -16,7 +16,8 @@ Data blocks contain telemetry data. The possible sub-types data blocks are liste
         0x05              & Angular velocity        \\
         0x06              & GNSS location           \\
         0x07              & GNSS metadata           \\
-        0x08 through 0x3F & Reserved for future use \\
+        0x08              & Humidity                \\
+        0x09 through 0xFF & Reserved for future use \\
         \bottomrule
     \end{tabular}
     \caption{Data Block Subtypes}
@@ -32,3 +33,4 @@ Data blocks contain telemetry data. The possible sub-types data blocks are liste
 \input{sections/packets/blocks/data/angularvel.tex}
 \input{sections/packets/blocks/data/gnssloc.tex}
 \input{sections/packets/blocks/data/gnssmeta.tex}
+\input{sections/packets/blocks/data/humidity.tex}

--- a/radio-packet-format/sections/packets/blocks/data/data.tex
+++ b/radio-packet-format/sections/packets/blocks/data/data.tex
@@ -2,6 +2,12 @@
 
 Data blocks contain telemetry data. The possible sub-types data blocks are listed in table \ref{table:data-subtypes}.
 
+Note that all \textbf{mission time} fields are measured in milliseconds since launch, and are all unsigned 32-bit
+integers.
+
+Any integer fields larger than 1 byte are in little-endian format. Any unsigned integers are in two's complement format.
+This is because fields are packaged using C structs on a little endian machine (the de-facto standard).
+
 \begin{table}[H]
     \centering
     \begin{tabular}{@{}ll@{}}

--- a/radio-packet-format/sections/packets/blocks/data/humidity.tex
+++ b/radio-packet-format/sections/packets/blocks/data/humidity.tex
@@ -1,7 +1,7 @@
 \subsubsection{Humidity}
 
-The humidity block is used to convey the relative humidity inside of the rocket. The format of the humidity block is described
-in figure \ref{format:telem-humidity}.
+The humidity block is used to convey the relative humidity inside of the rocket. The format of the humidity block is
+described in figure \ref{format:telem-humidity}.
 
 \begin{figure}[H]
     \centering
@@ -18,4 +18,5 @@ in figure \ref{format:telem-humidity}.
 The mission time when the measurement was taken.
 
 \paragraph{Humidity}
-The calculated relative humidity in percentage. This field is an unsigned 32 bit integer.
+The calculated relative humidity in ten thousandths of a percent (i.e 1\% is 100). This field is an unsigned 32 bit
+integer.

--- a/radio-packet-format/sections/packets/blocks/data/humidity.tex
+++ b/radio-packet-format/sections/packets/blocks/data/humidity.tex
@@ -1,0 +1,21 @@
+\subsubsection{Humidity}
+
+The humidity block is used to convey the relative humidity inside of the rocket. The format of the humidity block is described
+in figure \ref{format:telem-humidity}.
+
+\begin{figure}[H]
+    \centering
+    \begin{bytefield}[bitwidth=0.03\linewidth]{32}
+        \bitheader{0-31} \\
+        \wordbox{1}{Measurement Time} \\
+        \wordbox{1}{Humidity}
+    \end{bytefield}
+    \caption{Humidity Data Payload Format}
+    \label{format:telem-humidity}
+\end{figure}
+
+\paragraph{Measurement Time}
+The mission time when the measurement was taken.
+
+\paragraph{Humidity}
+The calculated relative humidity in percentage. This field is an unsigned 32 bit integer.


### PR DESCRIPTION
This pull request makes the addition of a humidity data block. This will encode humidity measurements from the rocket in ten thousandths of a percentage, for %RH readings accurate to two decimal points.