### PR TITLE
Use half minutes and a signed offset for timestamp

### DIFF
--- a/radio-packet-format/sections/block_formats.tex
+++ b/radio-packet-format/sections/block_formats.tex
@@ -1,7 +1,7 @@
 % Some information about block timestamps that will be needed for virtually all blocks
 \def\blocktimestampexp{
     \paragraph{Measurement Time}
-    An unsigned 16 bit integer in units of milliseconds. This timestamp is meant to be added as an offset to the base
+    A signed 16 bit integer in units of milliseconds. This timestamp is meant to be added as an offset to the base
     timestamp in the packet header. This is explained in section \ref{sec:pkt-hdr}.
 }
 

--- a/radio-packet-format/sections/packet_layout.tex
+++ b/radio-packet-format/sections/packet_layout.tex
@@ -61,19 +61,19 @@ Canadian HAM radio call sign.
 
 \paragraph{Timestamp}
 
-This field is an unsigned 16 bit integer representing a number of minutes since power on. This timestamp serves as a
-base timestamp to which measurement timestamp offsets are added to.
+This field is an unsigned 16 bit integer representing a number of half-minutes since power on. This timestamp serves as
+a base timestamp to which measurement timestamp offsets are added to.
 
-For instance, the packet header may contain a value of 1 in this field, indicating the base timestamp is 1 minute since
-power on. A subsequent block may be a temperature block with a measurement timestamp field containing the value of 12
+For instance, the packet header may contain a value of 1 in this field, indicating the base timestamp is 30 seconds since
+power on. A subsequent block may be a temperature block with a measurement timestamp field containing the value of +12
 milliseconds. This value is to be added to the packet header field, meaning that the temperature measurement was taken
-at 1 minute and 12 milliseconds after power on.
+at 30 seconds and 12 milliseconds after power on.
 
 This schema allows millisecond resolution on measurement time, while preserving a maximum mission duration of around
-1092 hours, as seen in equation \ref{eq:max-mission-time}
+546 hours, as seen in equation \ref{eq:max-mission-time}
 
 \begin{equation} \label{eq:max-mission-time}
-    \frac{2^{16} - 1}{60} = 1092.25 \\
+    \frac{2^{16} - 1}{2*60} = 546.125 \\
 \end{equation}
 
 \paragraph{Num Blocks}


### PR DESCRIPTION
With the absolute time being a full minute and offsets being unsigned, it is much harder to send an older measurement in a newer packet. With half-minutes and a signed offset, the log time is cut in half but a measurement's offset is always compatible with the previous and next half-minute to have occurred