### PR TITLE
Add error and status code block types

### DIFF
--- a/radio-packet-format/sections/block_formats.tex
+++ b/radio-packet-format/sections/block_formats.tex
@@ -19,3 +19,5 @@ Blocks have a type which indicates their contents. The possible block types are 
 \input{sections/temperature.tex}
 \input{sections/voltage.tex}
 \input{sections/magnetic.tex}
+\input{sections/status.tex}
+\input{sections/error.tex}

--- a/radio-packet-format/sections/error.tex
+++ b/radio-packet-format/sections/error.tex
@@ -1,0 +1,30 @@
+\subsection{Error Message}
+
+The error message block type reports information about failures in the telemetry system. The format of the error
+message payload is described in figure \ref{format:error-message}.
+
+\begin{figure}[H]
+    \centering
+    \begin{bytefield}[bitwidth=0.03\linewidth]{16}
+        \bitheader{0-15} \\
+        \wordbox{1}{Measurement Time} \\
+        \bitbox{3}{}
+        \bitbox{5}{PID}
+        \bitbox{8}{Error Code} \\
+    \end{bytefield}
+    \caption{Error message data block format}
+    \label{format:error-message}
+\end{figure}
+
+\blocktimestampexp
+
+\paragraph{PID}
+
+The PID (process ID) or originating process is a number that corresponds to the context that the error occurred in,
+denoting which process, thread, or hardware component the error occurred in. A value of 0x00 represents a general error,
+not specific to any context. Other values are left to the telemetry system to define.
+
+\paragraph{Error Codes}
+
+The error codes describe the specific type of error that has occurred. The value of 0x00 is defined as a general error,
+with an unknown source. Other values are left to the telemetry system to define.

--- a/radio-packet-format/sections/packet_layout.tex
+++ b/radio-packet-format/sections/packet_layout.tex
@@ -125,7 +125,9 @@ The block type field indicates the information contained in the block. Possible 
         Coordinates (latitude and longitude) & 0x07              \\
         Voltage                              & 0x08              \\
         Magnetic field                       & 0x09              \\
-        Reserved for future use              & 0x0A through 0xFF \\
+        Status message                       & 0x0A              \\
+        Error message                        & 0x0B              \\
+        Reserved for future use              & 0x0C through 0xFF \\
         \bottomrule
     \end{tabular}
     \caption{Block types}

--- a/radio-packet-format/sections/status.tex
+++ b/radio-packet-format/sections/status.tex
@@ -1,0 +1,46 @@
+\subsection{Status Message}
+
+The status message block type reports information about the current state of the telemetry system in integer codes,
+such as the current flight state or flight events that are detected. The format of the status message payload
+is described in figure \ref{format:status-message}.
+
+\begin{figure}[H]
+    \centering
+    \begin{bytefield}[bitwidth=0.03\linewidth]{16}
+        \bitheader{0-15} \\
+        \wordbox{1}{Measurement Time} \\
+        \bitbox{8}{Status Code} \\
+    \end{bytefield}
+    \caption{Status message data block format}
+    \label{format:status-message}
+\end{figure}
+
+\blocktimestampexp
+
+\paragraph{Status Code}
+
+A status code is an integer representing information about the rocket's state, the state of the telemetry system, or other information.
+The measurement time describes a time that the status code was valid, such as when a state change or event occurs, or any time afterwards.
+The same code can be transmitted multiple times to ensure that a receiver gets has an up to date picture of the telemetry system's
+operation. For example, the state of the telemetry system could be transmitted periodically. The possible status codes are described in
+\ref{table:status-message-codes}.
+
+\begin{table}[H]
+    \centering
+    \begin{tabular}{@{}ll@{}}
+        \toprule
+        Status message              & Value             \\
+        \midrule
+        Systems nominal             & 0x00              \\
+        Telemetry in idle state     & 0x01              \\
+        Telemetry in airborne state & 0x02              \\
+        Telemetry in landed state   & 0x03              \\
+        Rocket ascent detected      & 0x04              \\
+        Rocket apogee detected      & 0x05              \\
+        Rocket descent detected     & 0x06              \\
+        Reserved for future use     & 0x07 through 0xFF \\
+        \bottomrule
+    \end{tabular}
+    \caption{Status message codes}
+    \label{table:status-message-codes}
+\end{table}


### PR DESCRIPTION
Added error and status block types. Both have a measurement time to denote when the error or status update occurs, though I've written the status block to allow for re-transmission of the same status message as an update.

Status blocks
* Allow for state, event, and a nominal operation message. The nominal operation message could be left out, but it might be useful to have for startup or if there's error handling we do.

Error blocks
* Included fields for the originating process (in case we want to track down which thread caused an error, or in case we can attribute errors to specific pieces of hardware). For now, I've left the specific values as implementation defined besides 0x00, because I don't want to lock us into one design for the system or make our radio format outdated if we add another thread. We can just debug this after the flight or look up the values we chose on-demand.
* Included a field for severity. Chose some okay default options, leaving 3 left for future use. We probably don't need all of these, but I didn't know what to do with extra bits anyways. Let me know if they'd be better reserved.
* Left the definitions of error codes as implementation defined. I think we'll have a lot of these, and they can have very specific meanings if we just leave them to be defined by telemetry. I'm planning on having every error case have its own code so its easy to know exactly where an error came from.