### PR TITLE
Added count to block header

### DIFF
--- a/radio-packet-format/sections/packet_layout.tex
+++ b/radio-packet-format/sections/packet_layout.tex
@@ -1,7 +1,7 @@
 \section{Packet Layout}
 
 CU InSpace's radio packets consist of a packet header followed by one or more segments called blocks. Each block has
-its own header followed by a variable amount of data determined by the block type. The layout of a packet is shown in
+its own header followed by a variable amount of data determined by the block type and count. The layout of a packet is shown in
 figure \ref{format:packet}.
 
 \textbf{All fields in this specification are little endian.}
@@ -10,19 +10,12 @@ figure \ref{format:packet}.
     \centering
     \begin{bytefield}{16}
         \wordbox{2}{Packet Header} \\
-        \begin{rightwordgroup}{Block 1}
-            \wordbox{2}{Block Header} \\
-            \wordbox[lrt]{1}{Block Contents} \\
-            \skippedwords \\
-            \wordbox[lrb]{1}{}
-        \end{rightwordgroup} \\
-        \wordbox[]{1}{$\vdots$} \\[1ex]
-        \begin{rightwordgroup}{Block $N$}
-            \wordbox{2}{Block Header} \\
-            \wordbox[lrt]{1}{Block Contents} \\
-            \skippedwords \\
-            \wordbox[lrb]{1}{}
-        \end{rightwordgroup} \\
+        \wordbox{1}{Block Header} \\
+        \wordbox{1}{Block} \\
+        \wordbox{1}{Block} \\
+        \wordbox{1}{Block} \\
+        \wordbox{1}{Block Header} \\
+        \wordbox{1}{Block} \\
     \end{bytefield}
     \caption{Layout of radio packet}
     \label{format:packet}
@@ -38,7 +31,7 @@ describes the packet as a whole. The packet header follows the format described 
     \begin{bytefield}[bitwidth=0.03\linewidth]{32}
         \bitheader{0-31} \\
         \wordbox[lrt]{1}{Call Sign} \\ \bitbox[lr]{32}{} \\
-        \bitbox[lrb]{8}{} & \bitbox{16}{Timestamp} & \bitbox{8}{Num Blocks} \\
+        \bitbox[lrb]{8}{} & \bitbox{16}{Timestamp} & \bitbox{8}{Num Block Headers} \\
         & \bitbox{8}{Packet Number} \\
     \end{bytefield}
     \caption{Packet header format}
@@ -78,9 +71,9 @@ This schema allows millisecond resolution on measurement time, while preserving 
     \frac{2^{16} - 1}{2*60} = 546.125 \\
 \end{equation}
 
-\paragraph{Num Blocks}
+\paragraph{Num Block Headers}
 
-This field is an unsigned 8 bit integer that contains the total number of blocks in the packet.
+This field is an unsigned 8 bit integer that contains the total number of block headers in the packet.
 
 \paragraph{Packet Number}
 
@@ -91,14 +84,14 @@ whether any packets were lost in transmission.
 \subsection{Block Header}
 
 Every block starts with a block header. This header indicates the type of information contained in the subsequent
-block, which allows for parsing of the received data. The block header is formatted as described in Figure
+blocks, which allows for parsing of the received data. The block header is formatted as described in Figure
 \ref{format:block-header}.
 
 \begin{figure}[H]
     \centering
-    \begin{bytefield}[bitwidth=0.03\linewidth]{8}
-        \bitheader{0-7} \\
-        \bitbox{8}{Type} &
+    \begin{bytefield}[bitwidth=0.03\linewidth]{16}
+        \bitheader{0-15} \\
+        \bitbox{8}{Type} & \bitbox{8}{Count} \\
     \end{bytefield}
     \caption{Block header format}
     \label{format:block-header}
@@ -106,7 +99,7 @@ block, which allows for parsing of the received data. The block header is format
 
 \paragraph{Type}
 
-The block type field indicates the information contained in the block. Possible values are listed in table
+The block type field indicates the information contained in the blocks. Possible values are listed in table
 \ref{table:block-types}. Block types are discussed in more detail in section \ref{sec:block-formats}.
 
 \begin{table}[H]
@@ -133,3 +126,7 @@ The block type field indicates the information contained in the block. Possible 
     \caption{Block types}
     \label{table:block-types}
 \end{table}
+
+\paragraph{Count}
+
+This field is an unsigned 8 bit integer that contains the number of blocks following the header.


### PR DESCRIPTION
Because we now transmit more uniform sensor data we can optimize the spec a little

Packet block count becomes packet block header count

Block header gains a count field to count the number of blocks following it
